### PR TITLE
MS_WIN64 macros parameter for a 64 bit build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
     ext_modules = [module_curve],
     author_email='tare2.galal@gmail.com',
     description='curve25519 with ed25519 signatures, used by libaxolotl',
-    platforms='any'
+    platforms='any',
+    define_macros=[('MS_WIN64',None)]
 )


### PR DESCRIPTION
MS_WIN64 does not seem necessary but i put it here because can be useful in future for 64bit builds

[question where is suggested](https://stackoverflow.com/questions/2842469/python-undefined-reference-to-imp-py-initmodule4)