### PR TITLE
fix issue #5 builded on windows 64bit with tdm-gcc-64 / mingw-w64

### DIFF
--- a/curve25519module.c
+++ b/curve25519module.c
@@ -172,7 +172,7 @@ curve25519_functions[] = {
     PyMODINIT_FUNC
     initaxolotl_curve25519(void)
     {
-        (void)Py_InitModule("axolotl_curve25519", curve25519_functions);
+        (void)Py_InitModule4_64("axolotl_curve25519", curve25519_functions);
     }
 
 #endif


### PR DESCRIPTION
This update fix the build problem with Win64bit versions (tested on windows  10 pro) and compiling issue with mingw/gcc 64bit version (tested with tdm-gcc-64)